### PR TITLE
Code reverted - Duckuments updated.

### DIFF
--- a/catkin_ws/src/00-infrastructure/duckietown/include/duckietown_utils/yaml_pretty.py
+++ b/catkin_ws/src/00-infrastructure/duckietown/include/duckietown_utils/yaml_pretty.py
@@ -8,7 +8,7 @@ def yaml_load(s):
     try:
         l = yaml.load(s, Loader=yaml.RoundTripLoader)
     except:
-        l = yaml.load(s, Loader=yaml.Loader)
+        l = yaml.load(s, Loader=yaml.UnsafeLoader)
     return remove_unicode(l)
 
 def yaml_load_plain(s):
@@ -17,7 +17,7 @@ def yaml_load_plain(s):
     if s.startswith('...'):
         return None
     
-    l = yaml.load(s, Loader=yaml.Loader)
+    l = yaml.load(s, Loader=yaml.UnsafeLoader)
     return remove_unicode(l)
 
 def yaml_dump(s):


### PR DESCRIPTION
If I install the package `python-ruamel.yaml` via `apt` then Python complains about: "... no attribute 'UnsafeLoader'".
If I install the package `ruamel.yaml` via `pip` though, I don't get the error. 
Reverting to the previous version and updating the duckuments so that `ruamel.yaml` gets installed via `pip` rather than `apt`.