### PR TITLE
Export DUCKIETOWN_ROOT as the path relative to the environment.sh parent directory

### DIFF
--- a/environment.sh
+++ b/environment.sh
@@ -13,7 +13,7 @@ source /opt/ros/kinetic/setup.$shell
 echo "Setup ROS_HOSTNAME..."
 export HOSTNAME=$HOSTNAME
 export ROS_HOSTNAME=$HOSTNAME.local
-export DUCKIETOWN_ROOT=$HOME/duckietown
+export DUCKIETOWN_ROOT=$(pwd)
 
 echo "Setting up PYTHONPATH..."
 export PYTHONPATH=$DUCKIETOWN_ROOT/catkin_ws/src:$PYTHONPATH

--- a/environment.sh
+++ b/environment.sh
@@ -13,6 +13,8 @@ source /opt/ros/kinetic/setup.$shell
 echo "Setup ROS_HOSTNAME..."
 export HOSTNAME=$HOSTNAME
 export ROS_HOSTNAME=$HOSTNAME.local
+
+echo "Setting up DUCKIETOWN_ROOT..."
 export DUCKIETOWN_ROOT=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
 
 echo "Setting up PYTHONPATH..."

--- a/environment.sh
+++ b/environment.sh
@@ -13,7 +13,7 @@ source /opt/ros/kinetic/setup.$shell
 echo "Setup ROS_HOSTNAME..."
 export HOSTNAME=$HOSTNAME
 export ROS_HOSTNAME=$HOSTNAME.local
-export DUCKIETOWN_ROOT=$(pwd)
+export DUCKIETOWN_ROOT=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
 
 echo "Setting up PYTHONPATH..."
 export PYTHONPATH=$DUCKIETOWN_ROOT/catkin_ws/src:$PYTHONPATH


### PR DESCRIPTION
`DUCKIETOWN_ROOT` should always be the same directory as `environment.sh`. 

Note, this cannot be `pwd`. If `environment.sh` is called from another directory, `pwd` will return the directory from where the script is called. Getting the relative directory of `environment.sh` is non-trivial. See [this highly rated answer](https://stackoverflow.com/a/246128/1772342) on StackOverflow for a full explanation of why we use the ugly `$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )` instead of `$(pwd)`.