### PR TITLE
Fixed rosbag record's topic regexp

### DIFF
--- a/catkin_ws/src/10-lane-control/line_detector/launch/line_detector_bag.launch
+++ b/catkin_ws/src/10-lane-control/line_detector/launch/line_detector_bag.launch
@@ -7,7 +7,7 @@
 
     <!-- record all the file other -->
     <node pkg="rosbag" type="record" name="rosbag_record"
-          args="-e '/$(arg veh)/line_detector/*' -O $(arg bagout)"/>
+          args="-e '/line_detector_node/.*' -O $(arg bagout)"/>
 
     <remap from="/line_detector_node/image" to="/$(arg veh)/camera_node/image/compressed"/>
 


### PR DESCRIPTION
The regexp had two problems:
1. The line_detector node is in the global namespace
2. `.*` means "match all", not only `*`