### PR TITLE
Added a limitation to the turning radius

### DIFF
--- a/catkin_ws/src/05-teleop/dagu_car/launch/wheels_driver_node.launch
+++ b/catkin_ws/src/05-teleop/dagu_car/launch/wheels_driver_node.launch
@@ -1,7 +1,15 @@
 <launch>
     <arg name="veh" doc="Name of vehicle. ex: megaman"/>
-    <node ns="$(arg veh)" machine="$(arg veh)" pkg="dagu_car" type="wheels_driver_node.py" name="wheels_driver_node" output="screen" clear_params="true" required="true"/>
-    
+    <arg name="use_rad_lim" default="false" doc="true for using a minimal allowed turning radius. false for not using it."/>
+    <arg name="min_rad" default="0.08" doc="minimal turning radius duckiebot is allowed to drive."/>
+    <arg name="wheel_distance" default="0.103" doc="wheel distance of duckiebot."/>
+
+    <node ns="$(arg veh)" machine="$(arg veh)" pkg="dagu_car" type="wheels_driver_node.py" name="wheels_driver_node" output="screen" clear_params="true" required="true">
+      <param name="~use_rad_lim" value="$(arg use_rad_lim)"/>
+      <param name="~min_rad" value="$(arg min_rad)"/>
+      <param name="~wheel_distance" value="$(arg wheel_distance)"/>
+    </node>
+
     <!-- Subscriptions -->
     <!-- "~wheels_cmd": duckietown_msgs/WheelsCmd. Command for the wheels -->
 

--- a/catkin_ws/src/05-teleop/dagu_car/src/wheels_driver_node.py
+++ b/catkin_ws/src/05-teleop/dagu_car/src/wheels_driver_node.py
@@ -2,12 +2,19 @@
 import rospy
 from duckietown_msgs.msg import WheelsCmdStamped, BoolStamped
 from dagu_car.dagu_wheels_driver import DaguWheelsDriver
+import numpy as np
 
 class WheelsDriverNode(object):
     def __init__(self):
         self.node_name = rospy.get_name()
         rospy.loginfo("[%s] Initializing " %(self.node_name))
         self.estop=False
+
+        # Parameters for maximal turning radius
+        self.use_rad_lim        =   self.setupParam("~use_rad_lim", False)
+        self.min_rad            =   self.setupParam("~min_rad", 0.08)
+        self.wheel_distance     =   self.setupParam("~wheel_distance", 0.103)
+
 
         # Setup publishers
         self.driver = DaguWheelsDriver()
@@ -20,24 +27,79 @@ class WheelsDriverNode(object):
         self.sub_topic = rospy.Subscriber("~wheels_cmd", WheelsCmdStamped, self.cbWheelsCmd, queue_size=1)
         self.sub_e_stop = rospy.Subscriber("~emergency_stop", BoolStamped, self.cbEStop, queue_size=1)
 
+        self.params_update = rospy.Timer(rospy.Duration.from_sec(1.0), self.updateParams)
+
+
     def setupParam(self,param_name,default_value):
         value = rospy.get_param(param_name,default_value)
         rospy.set_param(param_name,value) #Write to parameter server for transparancy
         rospy.loginfo("[%s] %s = %s " %(self.node_name,param_name,value))
         return value
 
+    def updateParams(self,event):
+        self.use_rad_lim        =   rospy.get_param("~use_rad_lim")
+        self.min_rad            =   rospy.get_param("~min_rad")
+        self.wheel_distance     =   rospy.get_param("~wheel_distance")
+
     def cbWheelsCmd(self,msg):
         if self.estop:
             self.driver.setWheelsSpeed(left=0.0,right=0.0)
             return
+
+        # Check if radius limitation is enabled
+        if (self.use_rad_lim and (msg.vel_left != 0 or msg.vel_right != 0)):
+            self.checkAndAdjustRadius(msg)
+
+
         self.driver.setWheelsSpeed(left=msg.vel_left,right=msg.vel_right)
         # Put the wheel commands in a message and publish
         self.msg_wheels_cmd.header = msg.header
         # Record the time the command was given to the wheels_driver
-        self.msg_wheels_cmd.header.stamp = rospy.get_rostime()  
+        self.msg_wheels_cmd.header.stamp = rospy.get_rostime()
         self.msg_wheels_cmd.vel_left = msg.vel_left
         self.msg_wheels_cmd.vel_right = msg.vel_right
         self.pub_wheels_cmd.publish(self.msg_wheels_cmd)
+
+    def checkAndAdjustRadius(self, msg):
+        didAdjustment = False
+        # if both motor cmds do not have the same sign, we're demanding for an on-point turn (not allowed)
+        if (np.sign(msg.vel_left) != np.sign(msg.vel_right)):
+
+            # Simply set the smaller velocity to zero
+            if (abs(msg.vel_left) < abs(msg.vel_right)):
+                msg.vel_left = 0.0
+            else:
+                msg.vel_right = 0.0
+
+            didAdjustment = True
+
+        # set v1, v2 from msg velocities such that v2 > v1
+        if (abs(msg.vel_right) > abs(msg.vel_left)):
+            v1 = msg.vel_left
+            v2 = msg.vel_right
+        else:
+            v1 = msg.vel_right
+            v2 = msg.vel_left
+
+        # Check if a smaller radius than allowed is demanded
+        if (v1 == 0 or abs(v2 / v1) > (self.min_rad + self.wheel_distance/2.0)/(self.min_rad - self.wheel_distance/2.0)):
+
+            # adjust velocities evenly such that condition is fulfilled
+            delta_v = (v2-v1)/2 - self.wheel_distance/(4*self.min_rad)*(v1+v2)
+            v1 += delta_v
+            v2 -= delta_v
+            didAdjustment = True
+
+        # set msg velocities from v1, v2 with the same mapping as when we set v1, v2
+        if (abs(msg.vel_right) > abs(msg.vel_left)):
+            msg.vel_left = v1
+            msg.vel_right = v2
+        else:
+            msg.vel_left = v2
+            msg.vel_right = v1
+
+        return didAdjustment
+
 
     def cbEStop(self,msg):
         self.estop=not self.estop
@@ -55,7 +117,7 @@ if __name__ == '__main__':
     rospy.init_node('wheels_driver_node', anonymous=False)
     # Create the DaguCar object
     node = WheelsDriverNode()
-    # Setup proper shutdown behavior 
+    # Setup proper shutdown behavior
     rospy.on_shutdown(node.on_shutdown)
     # Keep it spinning to keep the node alive
     rospy.spin()


### PR DESCRIPTION
 ..so Duckiebots get a more realistic car behavior. Object is that duckiebots cannot turn on-point anymore just as a real vehicle - this limitation is necessary due to achieve a realistic implementation of parking and intersection navigation.

Turn it on by using
`rosparam set /![VEHICLE NAME]/wheels_driver_node/use_rad_lim true`

After confirmation and global agreement ( @liampaull , @AndreaCensi , @tanij ) will (maybe?) add a Subscriber that always turns the limitation on for any FSMState except of JOYSTICK_CONTROL (because that one is only used for debugging and all the others want to mimic a real car).

PS: it is necessary that turning radius > wheel_distance/2 for this implementation (which is anyway fulfilled since we don't allow on-point turning)