### PR TITLE
Did some fixes on open-loop intersection navigation.

### DIFF
--- a/catkin_ws/src/00-infrastructure/duckietown/config/baseline/stop_line_filter/stop_line_filter_node/default.yaml
+++ b/catkin_ws/src/00-infrastructure/duckietown/config/baseline/stop_line_filter/stop_line_filter_node/default.yaml
@@ -1,4 +1,4 @@
 #default parameters for stop_line_filter/stop_line_filter_node
-stop_distance: 0.2
+stop_distance: 0.25
 min_segs: 2
 off_time: 2


### PR DESCRIPTION
Someone forgot to add a subscriber to the switch operation in stop_line_filter_node :) Also, sometimes (very often) it occurred that the timer which deactivated the red line detection after an intersection such that the duckiebot didn't stop at an opposite red line wasn't called. Now, it works fine. 

Since it is open loop, double check your trim and use a gain of about 0.65.

Thanks alot to @ackthomas for your help again