### PR TITLE
Homography-problems fix

### DIFF
--- a/catkin_ws/src/10-lane-control/ground_projection/include/ground_projection/GroundProjection.py
+++ b/catkin_ws/src/10-lane-control/ground_projection/include/ground_projection/GroundProjection.py
@@ -121,8 +121,7 @@ class GroundProjection():
         for r in range(self.board_['height']):
         	for c in range(self.board_['width']):
         		src_pts.append(np.array([r * self.board_['square_size'] , c * self.board_['square_size']] , dtype='float32') + self.board_['offset'])
-        # OpenCV labels corners left-to-right, top-to-bottom
-        # so we reverse the groud points
+        # OpenCV labels corners left-to-right, top-to-bottom in most cases, but sometimes starts at bottom right
 
         # only reverse order if first point is at bottom right corner
         if (src_pts[0][0] > src_pts[self.board_['width']*self.board_['height']-1][0] and src_pts[0][1] > src_pts[self.board_['width']*self.board_['height']-1][1]):

--- a/catkin_ws/src/10-lane-control/ground_projection/include/ground_projection/GroundProjection.py
+++ b/catkin_ws/src/10-lane-control/ground_projection/include/ground_projection/GroundProjection.py
@@ -123,7 +123,10 @@ class GroundProjection():
         		src_pts.append(np.array([r * self.board_['square_size'] , c * self.board_['square_size']] , dtype='float32') + self.board_['offset'])
         # OpenCV labels corners left-to-right, top-to-bottom
         # so we reverse the groud points
-        src_pts.reverse()
+
+        # only reverse order if first point is at bottom right corner
+        if (src_pts[0][0] > src_pts[self.board_['width']*self.board_['height']-1][0] and src_pts[0][1] > src_pts[self.board_['width']*self.board_['height']-1][1]):
+            src_pts.reverse()
 
         # Compute homography from image to ground
         self.H, mask = cv2.findHomography(corners2.reshape(len(corners2), 2), np.array(src_pts), cv2.RANSAC)


### PR DESCRIPTION
Problem is or better was, that opencv's findChessboardCorner function gives you different orders of points depending on angle of the camera, see attachment. Added case to revert the order only if first point in array is at bottom right. Thanks alot to @theodorekoutros and @simonmuntwiler for their time

@liampaull please double-check, for @simonmuntwiler it's working now (he was one of those which had that problem).

First point in array is RED:
![take2](https://user-images.githubusercontent.com/32697515/33283456-27a5d9c2-d3ac-11e7-87dc-dbfafe5f923c.png)
![take3](https://user-images.githubusercontent.com/32697515/33283457-27c908a2-d3ac-11e7-874a-aac918f1ba18.png)

