### PR TITLE
Update ground_projection_node.py

### DIFF
--- a/catkin_ws/src/10-lane-control/ground_projection/src/ground_projection_node.py
+++ b/catkin_ws/src/10-lane-control/ground_projection/src/ground_projection_node.py
@@ -65,7 +65,7 @@ class GroundProjectionNode(object):
         self.pub_lineseglist_.publish(seglist_out)
 
     def get_ground_coordinate_cb(self,req):
-        return GetGroundCoordResponse(self.gp.pixel2ground(req.normalized_uv))
+        return GetGroundCoordResponse(self.gp.vector2ground(req.normalized_uv))
 
     def get_image_coordinate_cb(self,req):
         return GetImageCoordResponse(self.gp.ground2pixel(req.gp))


### PR DESCRIPTION
change line 68 from pixel2ground to vector2ground due to obstacle_safety_node.py calling this service with Vector2D() object passing
At default, if you run
$roslaunch duckietown_demos obstacle_avoid.launch 
on duckiebot, an error, Vector2D has no attribute 'u', will occur
which is caused by calling pixel2ground with argument p & p2, which is object of Vector2D
After changing calling pixel2ground to vector2ground, there'll be no error and can detect duck&cone and send object_too_close topic successfully