### PR TITLE
DUCKIEBOT_NAME.local is not accessible from the duckiebot

### DIFF
--- a/docker/env.sh
+++ b/docker/env.sh
@@ -8,7 +8,7 @@ if [ ! -z "$DUCKIEBOT_NAME" ] && [ ! -z "$DUCKIEBOT_IP" ]; then # We are running
     duckiebot_binding="$DUCKIEBOT_IP $DUCKIEBOT_NAME $DUCKIEBOT_NAME.local"
     echo "Writing \"$duckiebot_binding\" into /etc/hosts"
     echo $duckiebot_binding >> /etc/hosts
-    export ROS_MASTER_URI="http://$DUCKIEBOT_NAME.local:11311/"
+    export ROS_MASTER_URI="http://$DUCKIEBOT_NAME:11311/"
 else # We are running on the Duckiebot, which can always reach itself
     export ROS_MASTER_URI="http://localhost:11311/"
 fi


### PR DESCRIPTION
When running a Docker container on the Duckiebot, `$DUCKIEBOT_NAME.local` is not reachable by ping, but `$DUCKIEBOT_NAME` is. Instead, we need to set `ROS_MASTER_URI` to `http://$DUCKIEBOT_NAME:11311/`.