### PR TITLE
Do not overwrite ROS_MASTER_URI if set externally

### DIFF
--- a/docker/env.sh
+++ b/docker/env.sh
@@ -3,8 +3,9 @@
 MY_IP=$(hostname -I | cut -d " " -f 1)
 export ROS_IP=${MY_IP}
 echo "Setting ROS_IP to host IP, which is $ROS_IP"
-
-if [ ! -z "$DUCKIEBOT_NAME" ] && [ ! -z "$DUCKIEBOT_IP" ]; then # We are running on the Desktop
+if [ ! -z "$ROS_MASTER_URI" ]; then
+    echo "ROS_MASTER_URI was externally set to \"$ROS_MASTER_URI\", skipping configuration."
+elif [ ! -z "$DUCKIEBOT_NAME" ] && [ ! -z "$DUCKIEBOT_IP" ]; then # We are running on the Desktop
     duckiebot_binding="$DUCKIEBOT_IP $DUCKIEBOT_NAME $DUCKIEBOT_NAME.local"
     echo "Writing \"$duckiebot_binding\" into /etc/hosts"
     echo $duckiebot_binding >> /etc/hosts


### PR DESCRIPTION
In the `docker/env.sh` script, we should not overwrite `ROS_MASTER_URI` as it may have been set externally, e.g. on the Docker CLI.