### PR TITLE
needed to make the tests pass when installing pi-camera

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,7 @@ jobs:
               DUCKIEFLEET_ROOT: /root/duckiefleet
               DUCKIETOWN_ROOT: /root/project
               DUCKIETOWN_DATA: /root/duckietown-data
-	      READTHEDOCS: True 
+              READTHEDOCS: True # needed to make Picamera install 
               COLUMNS: 160
      parallelism: 4
      resource_class: large

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,7 @@ jobs:
               DUCKIEFLEET_ROOT: /root/duckiefleet
               DUCKIETOWN_ROOT: /root/project
               DUCKIETOWN_DATA: /root/duckietown-data
-              READTHEDOCS: True # needed to make Picamera install 
+
               COLUMNS: 160
      parallelism: 4
      resource_class: large
@@ -20,7 +20,7 @@ jobs:
                 # python -m venv venv
                 #
                 # . venv/bin/activate
-
+                export READTHEDOCS=True # needed to make Picamera install
                 pip install --upgrade -r requirements.txt
 
                 make python-module-stats

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,8 +7,6 @@ jobs:
               DUCKIEFLEET_ROOT: /root/duckiefleet
               DUCKIETOWN_ROOT: /root/project
               DUCKIETOWN_DATA: /root/duckietown-data
-	      # The following disables the PiCamera model from checking
-	      # whether it is being run on a Raspi or not	
 	      READTHEDOCS: True 
               COLUMNS: 160
      parallelism: 4

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,6 +7,9 @@ jobs:
               DUCKIEFLEET_ROOT: /root/duckiefleet
               DUCKIETOWN_ROOT: /root/project
               DUCKIETOWN_DATA: /root/duckietown-data
+	      # The following disables the PiCamera model from checking
+	      # whether it is being run on a Raspi or not	
+	      READTHEDOCS: True 
               COLUMNS: 160
      parallelism: 4
      resource_class: large


### PR DESCRIPTION
see [here](https://github.com/balena-io-projects/balena-rpi-python-picamera/issues/8): we need to set an env var so that the PiCamera pip install doesn't check if it's on a Raspi for the tests to pass 